### PR TITLE
20-Make-PA_pgdx-output-optional-when-saving-files

### DIFF
--- a/epm/epm.py
+++ b/epm/epm.py
@@ -146,6 +146,7 @@ def launch_epm(scenario,
                path_cplex_file='cplex.opt',
                folder_input=None,
                path_engine_file=False,
+               solvemode=2,
                prefix=''#'simulation_'
                ):
     """
@@ -209,6 +210,7 @@ def launch_epm(scenario,
                                                     "--TREATMENT_FILE {}".format(path_treatment_file),
                                                     "--DEMAND_FILE {}".format(path_demand_file),
                                                     "--FOLDER_INPUT {}".format(folder_input),
+                                                    "--SOLVEMODE {}".format(solvemode)
                                                     ] + path_args
 
     # Print the command

--- a/epm/main.gms
+++ b/epm/main.gms
@@ -912,17 +912,21 @@ if (card(mipopt),
 PA.optfile = 1;
 
 * ############## SOLVE ##############
-* Solvemode == 1 solves as usual but generates a savepoint file to skip the solve
-* Solvemode == 0 uses a savepoint file to skip the solve
-* This speeds up development of post solve features
+* SOLVEMODE == 2 solves as usual
+* SOLVEMODE == 1 solves as usual but generates a savepoint file to skip the solve
+* SOLVEMODE == 0 uses a savepoint file to skip the solve (This speeds up development of post solve features)
 
-$if not set SOLVE $set SOLVE 1
+$if not set SOLVEMODE $set SOLVEMODE 2 
+$log LOG: Solving in SOLVEMODE = "%SOLVEMODE%"
 
-$ifThenI.solvemode %SOLVE% == 1
+$ifThenI.solvemode %SOLVEMODE% == 2
+*  Solve model as usual
+   Solve PA using MIP minimizing vNPVcost;
+$elseIfI.solvemode %SOLVEMODE% == 1
 *  Save model state at the end of execution (useful for debugging or re-running from a checkpoint)
    PA.savepoint = 1;
    Solve PA using MIP minimizing vNPVcost;
-$elseIfI.solvemode %SOLVE% == 0
+$elseIfI.solvemode %SOLVEMODE% == 0
 *  Only generate the model (no solve) 
    PA.JustScrDir = 1;
    Solve PA using MIP minimizing vNPVcost;


### PR DESCRIPTION
This PR adds a new compile time variable (`SOLVEMODE`) to control the behaviour of savepoint files.

* SOLVEMODE == 2 solves as usual
* SOLVEMODE == 1 solves as usual but generates a savepoint file to skip the solve
* SOLVEMODE == 0 uses a savepoint file to skip the solve (This speeds up development of post solve features)

The new compile time variable is also added to the gams command which is called from `epm.py`.

Closes #20