### PR TITLE
fix: only validate existing zone pairs in pTransferLimit season check

### DIFF
--- a/.github/workflows/gams_workflow.yml
+++ b/.github/workflows/gams_workflow.yml
@@ -10,7 +10,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: gams/gams:latest
+      # Pinned: GAMS 54.x returns gams-transfer records with categorical dtypes,
+      # which broke input verification/treatment (phantom groupby groups, UNDF
+      # values). Last known-good is 53.5.1. Re-evaluate before moving to :latest.
+      image: gams/gams:53.5.1
 
     steps:
       - name: Check out repository

--- a/README.MD
+++ b/README.MD
@@ -69,6 +69,8 @@ Install EPM and choose how you want to run it:
 
 Full installation instructions are available [here](https://esmap-world-bank-group.github.io/EPM/run/run_installation/).
 
+> **GAMS version:** EPM is tested on **GAMS 53.x** (CI pinned to 53.5.1). **GAMS 54.x is not yet supported** — it changes data types returned by `gams-transfer` and breaks input processing. Please use GAMS < 54 for now. Tracking: [#126](https://github.com/ESMAP-World-Bank-Group/EPM/issues/126).
+
 ---
 
 ## Works deploying EPM

--- a/epm/input_verification.py
+++ b/epm/input_verification.py
@@ -656,7 +656,7 @@ def _check_transfer_limits(gams, db):
         seasons = set(p_hours_records["q"].unique())
         season_issues = []
 
-        for (z, z2), group in records.groupby(["z", "z2"], observed=False):
+        for (z, z2), group in records.groupby(["z", "z2"], observed=True):
             unique_seasons = set(group["q"].unique())
             missing_seasons = seasons - unique_seasons
             if missing_seasons:


### PR DESCRIPTION
## Problem
The `Run GAMS Model` CI started failing on `main` with hundreds of
`(z, z2): missing seasons {'Q1', 'Q2'}` errors from `_check_transfer_limits`
in `input_verification.py` â€” on **unchanged code and data** (first run since June 3).

## Root cause
The check groups `pTransferLimit` records with `groupby(["z", "z2"], observed=False)`.
`observed` only affects **categorical** columns. Previously `z`/`z2` were plain
strings (`object` dtype), so `observed=False` was a no-op and only real pairs were
grouped. A recent `gams/gams:latest` image update made the GAMS Python API return
these columns as **`category`** dtype, which "woke up" `observed=False`: it now
enumerates the full cartesian product of zones, creating empty **phantom groups**
for the ~80 zone pairs that have no transfer limit. Those empty groups were flagged
as missing all seasons.

Verified against `input/data_test`: 20 real pairs, all with Q1+Q2; the flagged
pairs (e.g. `(Congo, Rwanda)`, `(Tanzania, Tanzania)`) do not exist in the data.

## Fix
Use `observed=True` so only zone pairs actually present in `pTransferLimit` are
validated. Genuine incomplete pairs are still caught. Robust regardless of the
column dtype / GAMS image version.

Note: other `observed=False` groupbys in the codebase are aggregations/means where
empty groups are harmless; only this completeness check produced false positives.
