### PR TITLE
test(output): stop asserting object dtype in the guard precondition

### DIFF
--- a/tools/test_output_treatment.py
+++ b/tools/test_output_treatment.py
@@ -89,7 +89,11 @@ def test_cumulative_sum_adds_instead_of_concatenating():
         "value": ["1", "2", "EPS", "4"],
     }).to_csv(src, index=False)
 
-    assert pd.read_csv(src)["value"].dtype == object, "test data must trip dtype inference"
+    # Not `dtype == object`: pandas 3 reads text columns as `str`, and either way
+    # what matters is that the column is not numeric, which is what breaks cumsum.
+    assert not pd.api.types.is_numeric_dtype(
+        pd.read_csv(src)["value"]
+    ), "test data must trip dtype inference"
     assert ot.calculate_cumulative(src, dst, log_func=lambda m: None)
 
     got = pd.read_csv(dst).sort_values("y")["value"].tolist()


### PR DESCRIPTION
The guard's cumsum test first checks that its own fixture actually trips dtype inference, since a fixture pandas reads as numeric would exercise nothing. It asserted `dtype == object`, which pandas 3 broke: text columns now come back as `str`, so the precondition failed on CI while the six other tests passed and the protection itself was never in question.

Assert what the check is really about — the column is not numeric, which is what makes cumsum concatenate — so it holds under both dtypes.

Verified locally on pandas 2.3.3 (7/7). CI covers the newer pandas.

<!--
Thanks for contributing! Please fill in the sections below.
Keep what's relevant, delete what isn't.
-->

## Summary

<!-- What does this PR do, and why? -->

## Related issues

<!-- e.g. "Closes #123", "Refs #456". -->

## Changes

<!-- Bullet the main changes so a reviewer can scan them. -->
-

## How was this tested?

<!-- Commands run, scenarios checked, CI, manual verification… -->

## Checklist

- [ ] The change is focused and the description explains the "why".
- [ ] I tested the change (or explained why testing isn't applicable).
- [ ] Docs/README updated if behavior or usage changed.
- [ ] No secrets, credentials, or confidential data are included.
